### PR TITLE
Adds scroll padding for anchor links

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -9,6 +9,7 @@
 
 html {
   background: $color-darkest;
+  scroll-padding-top: 5rem;
 }
 
 body {


### PR DESCRIPTION
Adds ~80px head room when jumping to anchor links on a page. Will break when run locally, without #5.