### PR TITLE
Prevent table from overflowing on small devices

### DIFF
--- a/_sass/_junkdrawer.scss
+++ b/_sass/_junkdrawer.scss
@@ -245,9 +245,9 @@
 }
 
 .style-table {
-  table-layout: fixed;
-  max-width: 100%;
   width: 100%;
+  max-width: 100%;
+  table-layout: fixed;
 
   th,
   td {
@@ -260,8 +260,8 @@
   }
 
   td {
-    word-break: break-word;
     display: table-cell;
+    word-break: break-word;
   }
 }
 

--- a/_sass/_junkdrawer.scss
+++ b/_sass/_junkdrawer.scss
@@ -249,19 +249,19 @@
   max-width: 100%;
   width: 100%;
 
+  th,
+  td {
+    padding: 0.5rem;
+    border-bottom: $border-thin solid $color-border;
+  }
+
   th {
     text-align: left;
   }
 
   td {
-    padding: 0.5rem;
-    border-bottom: $border-thin solid $color-border;
     word-break: break-word;
     display: table-cell;
-  }
-
-  .fix {
-    min-width: 15rem;
   }
 }
 

--- a/_sass/_junkdrawer.scss
+++ b/_sass/_junkdrawer.scss
@@ -263,6 +263,16 @@
     display: table-cell;
     word-break: break-word;
   }
+
+  .swatch {
+    position: relative;
+    top: 0.075rem;
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    margin-right: 0.5rem;
+    border-radius: 0.25rem;
+  }
 }
 
 .u-font-weight-light {

--- a/_sass/_junkdrawer.scss
+++ b/_sass/_junkdrawer.scss
@@ -245,6 +245,10 @@
 }
 
 .style-table {
+  table-layout: fixed;
+  max-width: 100%;
+  width: 100%;
+
   th {
     text-align: left;
   }
@@ -252,6 +256,8 @@
   td {
     padding: 0.5rem;
     border-bottom: $border-thin solid $color-border;
+    word-break: break-word;
+    display: table-cell;
   }
 
   .fix {

--- a/index.html
+++ b/index.html
@@ -12,10 +12,9 @@ layout: default
     {%-for key in site.data.variables-%}
     {%-assign varName = key[0]-%}
     {%-assign varValue = key[1]-%}
-    {%-capture inline-%}{%-if varName contains '$color-'-%}border-left: 2rem solid {{varValue}}; padding: .5rem;{%-endif-%}{%-endcapture-%}
     <tr>
       <td>{{varName}}</td>
-      <td style="{{inline}}" class="{{varName | replace: "$", "u-"}}">{{varValue}}</td>
+      <td class="{{varName | replace: "$", "u-"}}">{%-if varName contains '$color-'-%}<div class="swatch" style="background-color: {{varValue}}"></div>{%-endif-%}{{varValue}}</td>
     </tr>
     {%-endfor-%}
   </tbody>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ layout: default
     {%-assign varValue = key[1]-%}
     <tr>
       <td>{{varName}}</td>
-      <td class="{{varName | replace: "$", "u-"}}">{%-if varName contains '$color-'-%}<div class="swatch" style="background-color: {{varValue}}"></div>{%-endif-%}{{varValue}}</td>
+      <td><div class="{{varName | replace: "$", "u-"}}">{%-if varName contains '$color-'-%}<div class="swatch" style="background-color: {{varValue}}"></div>{%-endif-%}{{varValue}}</div></td>
     </tr>
     {%-endfor-%}
   </tbody>


### PR DESCRIPTION
Noticed that the table overflows on smaller devices, this PR helps make the content more flexible and styles `th` similarly as `td`.