### PR TITLE
Placeholder 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,9 @@
+---
+layout: default
+title: 404
+---
+
+<div class="page-404">
+<h1>404</h1>
+<p>File not found</p>
+</div>

--- a/_sass/_404.scss
+++ b/_sass/_404.scss
@@ -1,0 +1,6 @@
+.page-404 {
+  text-align: center;
+  h1 {
+    font-size: 6rem;
+  }
+}

--- a/_sass/great-great.scss
+++ b/_sass/great-great.scss
@@ -4,3 +4,4 @@
 @import "base";
 @import "junkdrawer";
 @import "home";
+@import "404";

--- a/great-great-jekyll-theme.gemspec
+++ b/great-great-jekyll-theme.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://doublegreat.dev"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README|404.html)!i) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README|404.html)}i) }
 
   spec.add_runtime_dependency "jekyll", "~> 3.8.7"
 

--- a/great-great-jekyll-theme.gemspec
+++ b/great-great-jekyll-theme.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://doublegreat.dev"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README)!i) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README|404.html)!i) }
 
   spec.add_runtime_dependency "jekyll", "~> 3.8.7"
 

--- a/great-great-jekyll-theme.gemspec
+++ b/great-great-jekyll-theme.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://doublegreat.dev"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README|404.html)}i) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README|404.html)!i) }
 
   spec.add_runtime_dependency "jekyll", "~> 3.8.7"
 


### PR DESCRIPTION
Nothing creative yet, but wanted to get a 404 page started. I'm also curious if this root file will be included in the theme or not. I'll test locally.

![image](https://user-images.githubusercontent.com/2180540/88493940-bacdc600-cf81-11ea-9dee-34bd1cebfcdc.png)

Ref #12 