### PR TITLE
Add triggerMenuHide function

### DIFF
--- a/assets/navigation.js
+++ b/assets/navigation.js
@@ -25,25 +25,26 @@ function menuHide() {
   menuButton.setAttribute("aria-expanded", "false");
 }
 
+function triggerMenuHide(event) {
+  if (!nav.contains(event.target)) {
+    menuHide();
+  }
+}
+
 // hide menu when focus is off of the menu button or page links
 document.addEventListener(
   "focusin",
-  function () {
-    var active = document.activeElement;
-    if (active.id !== "db-menu-button" && active.className !== "db-page-link") {
-      menuHide();
-    }
+  function (event) {
+    triggerMenuHide(event);
   },
   true
 );
 
-// hiden menu when click is outside the navigation
+// hide menu when click is outside the navigation
 document.addEventListener(
   "click",
   function (event) {
-    if (!nav.contains(event.target)) {
-      menuHide();
-    }
+    triggerMenuHide(event);
   },
   true
 );


### PR DESCRIPTION
This PR cleans up the navigation code by adding a triggerMenuHide function which is used for both focusin and click event listeners.