### PR TITLE
Add layout documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,9 +11,9 @@ github: double-great/great-great-jekyll-theme
 permalink: /:title/
 
 header_pages:
-  - documentation.md
   - index.html
-  - post.md
+  - documentation.md
+  - demo/index.md
 
 plugins:
   - jekyll-feed

--- a/_config.yml
+++ b/_config.yml
@@ -11,8 +11,9 @@ github: double-great/great-great-jekyll-theme
 permalink: /:title/
 
 header_pages:
-  - post.md
+  - documentation.md
   - index.html
+  - post.md
 
 plugins:
   - jekyll-feed

--- a/_data/layouts.yml
+++ b/_data/layouts.yml
@@ -8,11 +8,11 @@ home:
     - list_title: "sets an `h1` heading for the page."
     - show_date: "show the date with each post."
     - show_excerpts: "show the first paragraph with each post."
-    - list_type: "if set to `cards` all posts will use the `home/cards.html` include."
+    - list_type: "if set to `cards`, all posts will use the `home/cards.html` include."
 page:
   description: "A standard page with an `h1` title."
 
 post:
   description: "A standard post with an `h1` title and date."
   frontmatter:
-    - modified_date: "displays the date the page was modified."
+    - modified_date: "display the date the page was modified."

--- a/_data/layouts.yml
+++ b/_data/layouts.yml
@@ -1,0 +1,18 @@
+default:
+  description: "Base code for every layout."
+  frontmatter:
+    - "`css` add CSS to the head of the page."
+home:
+  description: "A home page layout for sites with posts."
+  frontmatter:
+    - "`list_title` sets an `h1` heading for the page."
+    - "`show_date` show the date with each post."
+    - "`show_excerpts` show the first paragraph with each post."
+    - "`list_type` if set to `cards` all posts will use the `home/cards.html` include."
+page:
+  description: "A standard page with an `h1` title."
+
+post:
+  description: "A standard post with an `h1` title and date."
+  frontmatter:
+    - "`modified_date` displays the date the page was modified."

--- a/_data/layouts.yml
+++ b/_data/layouts.yml
@@ -1,18 +1,18 @@
 default:
   description: "Base code for every layout."
   frontmatter:
-    - "`css` add CSS to the head of the page."
+    - css: "add CSS to the head of the page."
 home:
   description: "A home page layout for sites with posts."
   frontmatter:
-    - "`list_title` sets an `h1` heading for the page."
-    - "`show_date` show the date with each post."
-    - "`show_excerpts` show the first paragraph with each post."
-    - "`list_type` if set to `cards` all posts will use the `home/cards.html` include."
+    - list_title: "sets an `h1` heading for the page."
+    - show_date: "show the date with each post."
+    - show_excerpts: "show the first paragraph with each post."
+    - list_type: "if set to `cards` all posts will use the `home/cards.html` include."
 page:
   description: "A standard page with an `h1` title."
 
 post:
   description: "A standard post with an `h1` title and date."
   frontmatter:
-    - "`modified_date` displays the date the page was modified."
+    - modified_date: "displays the date the page was modified."

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,4 +14,5 @@
     type="image/x-icon"
   />
   {%- feed_meta -%} {%- if site.custom_head %}{{site.custom_head}}{%- endif -%}
+  {%- if page.css -%}<style>{{page.css}}</style>{%- endif -%}
 </head>

--- a/_includes/home/list.html
+++ b/_includes/home/list.html
@@ -1,7 +1,7 @@
 <ul class="post-list">
   {%- for post in posts -%}
   <li>
-    {% if post.show_date %}<span class="post-meta"
+    {% if page.show_date %}<span class="post-meta"
       >{{ post.date | date: "%b %-d, %Y" }}</span
     >{% endif %}
     <h2>
@@ -9,7 +9,7 @@
         {{ post.title | escape }}
       </a>
     </h2>
-    {%- if site.show_excerpts -%} {{ post.excerpt }} {%- endif -%}
+    {%- if page.show_excerpts -%} {{ post.excerpt }} {%- endif -%}
   </li>
   {%- endfor -%}
 </ul>

--- a/demo/_posts/2020-09-04-post-3.md
+++ b/demo/_posts/2020-09-04-post-3.md
@@ -1,7 +1,6 @@
 ---
 layout: post
-title: Sample post
-date: 2020-07-07
+title: Sample post 3
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.

--- a/demo/_posts/2020-09-05-post-2.md
+++ b/demo/_posts/2020-09-05-post-2.md
@@ -1,0 +1,30 @@
+---
+layout: post
+title: Sample post 2
+---
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
+
+## Heading 2
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+### Heading 3
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+### Heading 3
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## Heading 2
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+### Heading 3
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+#### Heading 4
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/demo/_posts/2020-09-06-post-1.md
+++ b/demo/_posts/2020-09-06-post-1.md
@@ -1,0 +1,30 @@
+---
+layout: post
+title: Sample post 1
+---
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
+
+## Heading 2
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+### Heading 3
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+### Heading 3
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## Heading 2
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+### Heading 3
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+#### Heading 4
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/demo/index.md
+++ b/demo/index.md
@@ -1,0 +1,7 @@
+---
+title: Demo site
+layout: home
+show_excerpts: true
+show_date: true
+list_title: Posts
+---

--- a/documentation.md
+++ b/documentation.md
@@ -8,6 +8,7 @@ css: |
   table td,
   table tr {
     word-break: unset;
+    vertical-align: top;
   }
 ---
 
@@ -17,6 +18,6 @@ Documentation for building sites with the Great Great Jekyll theme.
 
 | Layout                                        | Description | Frontmatter               |
 | --------------------------------------------- | ----------- | ------------------------- |
-| {% for layout in site.data.layouts %}{{layout | first}}     | {{layout[1].description}} | {%for matter in layout[1].frontmatter %}{{matter}}<br>{% endfor %} |
+| {% for layout in site.data.layouts %}{{layout | first}}     | {{layout[1].description}} | {% for item in layout[1].frontmatter %}`{{item | first | first}}` - {{item | first | last}}<br>{% endfor %} |
 
 {% endfor %}

--- a/documentation.md
+++ b/documentation.md
@@ -14,6 +14,19 @@ css: |
 
 Documentation for building sites with the Great Great Jekyll theme.
 
+## Site navigation
+
+To add items to the site navigation, add `header_pages` to `_config.yml`. The value is an array of filenames.
+
+Example:
+
+```yaml
+header_pages:
+  - index.html
+  - documentation.md
+  - demo/index.md
+```
+
 ## Layouts
 
 | Layout                                        | Description | Frontmatter               |

--- a/documentation.md
+++ b/documentation.md
@@ -27,6 +27,11 @@ header_pages:
   - demo/index.md
 ```
 
+## Header
+
+- Set the title of the page in `_config.yml` with the `title` property.
+- By default, the site uses the Double Great pretzel logo (<span style="width: 1rem; display: inline-block">{% include icon/logo.svg %}</span>) next to the title of the page in the header. To override the logo, save a new logo at `_includes/icon/logo.svg`.
+
 ## Layouts
 
 Set the layout for a Jekyll page in the frontmatter, example: `layout: page`.
@@ -36,3 +41,8 @@ Set the layout for a Jekyll page in the frontmatter, example: `layout: page`.
 | {% for layout in site.data.layouts %}{{layout | first}}     | {{layout[1].description}} | {% for item in layout[1].frontmatter %}`{{item | first | first}}` - {{item | first | last}}<br>{% endfor %} |
 
 {% endfor %}
+
+## Footer
+
+- Set the description of the footer in `_config.yml` using the `description` property.
+- Add a link to the site's GitHub repository in `_config.yml` using the `github` property.

--- a/documentation.md
+++ b/documentation.md
@@ -1,0 +1,22 @@
+---
+title: Documentation
+layout: page
+css: |
+  table {
+    table-layout: fixed;
+  }
+  table td,
+  table tr {
+    word-break: unset;
+  }
+---
+
+Documentation for building sites with the Great Great Jekyll theme.
+
+## Layouts
+
+| Layout                                        | Description | Frontmatter               |
+| --------------------------------------------- | ----------- | ------------------------- |
+| {% for layout in site.data.layouts %}{{layout | first}}     | {{layout[1].description}} | {%for matter in layout[1].frontmatter %}{{matter}}<br>{% endfor %} |
+
+{% endfor %}

--- a/documentation.md
+++ b/documentation.md
@@ -14,11 +14,11 @@ css: |
 
 Documentation for building sites with the Great Great Jekyll theme.
 
-## Site navigation
+## Header
 
-To add items to the site navigation, add `header_pages` to `_config.yml`. The value is an array of filenames.
-
-Example:
+- Set the title of the page in `_config.yml` with the `title` property.
+- By default, the site uses the Double Great pretzel logo (<span style="width: 1rem; display: inline-block">{% include icon/logo.svg %}</span>) next to the title of the page in the header. To override the logo, save a new logo at `_includes/icon/logo.svg`.
+- To add items to the site navigation, add `header_pages` to `_config.yml`. The value is an array of filenames. Example:
 
 ```yaml
 header_pages:
@@ -27,18 +27,13 @@ header_pages:
   - demo/index.md
 ```
 
-## Header
-
-- Set the title of the page in `_config.yml` with the `title` property.
-- By default, the site uses the Double Great pretzel logo (<span style="width: 1rem; display: inline-block">{% include icon/logo.svg %}</span>) next to the title of the page in the header. To override the logo, save a new logo at `_includes/icon/logo.svg`.
-
 ## Layouts
 
 Set the layout for a Jekyll page in the frontmatter, example: `layout: page`.
 
-| Layout                                        | Description | Frontmatter               |
-| --------------------------------------------- | ----------- | ------------------------- |
-| {% for layout in site.data.layouts %}{{layout | first}}     | {{layout[1].description}} | {% for item in layout[1].frontmatter %}`{{item | first | first}}` - {{item | first | last}}<br>{% endfor %} |
+| Layout                                                    | Description               | Frontmatter                                                                |
+| --------------------------------------------------------- | ------------------------- | -------------------------------------------------------------------------- |
+| {% for layout in site.data.layouts %}`{{layout | first}}` | {{layout[1].description}} | {% for item in layout[1].frontmatter %}`{{item | first | first}}` - {{item | first | last}}<br>{% endfor %} |
 
 {% endfor %}
 

--- a/documentation.md
+++ b/documentation.md
@@ -29,6 +29,8 @@ header_pages:
 
 ## Layouts
 
+Set the layout for a Jekyll page in the frontmatter, example: `layout: page`.
+
 | Layout                                        | Description | Frontmatter               |
 | --------------------------------------------- | ----------- | ------------------------- |
 | {% for layout in site.data.layouts %}{{layout | first}}     | {{layout[1].description}} | {% for item in layout[1].frontmatter %}`{{item | first | first}}` - {{item | first | last}}<br>{% endfor %} |

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 ---
-title: Style Guide
+title: Style guide
 layout: page
 ---
 

--- a/index.html
+++ b/index.html
@@ -1,8 +1,7 @@
 ---
 title: Style Guide
-layout: default
+layout: page
 ---
-<h1>{{ page.title }}</h1>
 
 <h2 id="variables">Variables</h2>
 


### PR DESCRIPTION
- Add documentation to using the theme
- Add demo site for testing
- Add `css` frontmatter property for styles specific to the page.
- 🚨 Add breaking change `site.show_excerpts` should now be set in the home page file's frontmatter.

Fixes #3 