### PR TITLE
Update browserslist config

### DIFF
--- a/.browserlistrc
+++ b/.browserlistrc
@@ -1,3 +1,0 @@
-# Browsers that we support
-
-> .5% in US and last 2 version

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,4 @@
+# Browsers that we support
+# run `npx browserslist` in this directory to see list
+
+defaults and > .5% in US, IE 11

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -144,7 +144,6 @@
 
     "plugin/no-unsupported-browser-features": [true, {
       "severity": "warning",
-      "browsers": ["> .5% in US and last 2 version"],
       "ignore": [
         "calc",
         "css-featurequeries",

--- a/package-lock.json
+++ b/package-lock.json
@@ -768,9 +768,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001103",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001103.tgz",
-      "integrity": "sha512-EJkTPrZrgy712tjZ7GQDye5A67SQOyNS6X9b6GS/e5QFu5Renv5qfkx3GHq1S+vObxKzbWWYuPO/7nt4kYW/gA==",
+      "version": "1.0.30001142",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001142.tgz",
+      "integrity": "sha512-pDPpn9ankEpBFZXyCv2I4lh1v/ju+bqb78QfKf+w9XgDAFWBwSYPswXqprRdrgQWK0wQnpIbfwRjNHO1HWqvoQ==",
       "dev": true
     },
     "caseless": {
@@ -4239,9 +4239,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
-      "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true
     },
     "pretty-quick": {
@@ -5298,9 +5298,9 @@
       "dev": true
     },
     "stylelint": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.1.tgz",
-      "integrity": "sha512-qzqazcyRxrSRdmFuO0/SZOJ+LyCxYy0pwcvaOBBnl8/2VfHSMrtNIE+AnyJoyq6uKb+mt+hlgmVrvVi6G6XHfQ==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.2.tgz",
+      "integrity": "sha512-mmieorkfmO+ZA6CNDu1ic9qpt4tFvH2QUB7vqXgrMVHe5ENU69q7YDq0YUg/UHLuCsZOWhUAvcMcLzLDIERzSg==",
       "dev": true,
       "requires": {
         "@stylelint/postcss-css-in-js": "^0.37.2",
@@ -5395,12 +5395,6 @@
             "postcss": "^7.0.32",
             "postcss-value-parser": "^4.1.0"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001129",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001129.tgz",
-          "integrity": "sha512-9945fTVKS810DZITpsAbuhQG7Lam0tEfVbZlsBaCFZaszepbryrArS05PWmJSBQ6mta+v9iz0pUIAbW1eBILIg==",
-          "dev": true
         },
         "chalk": {
           "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "test": "npm run lint",
     "pretty-quick": "pretty-quick",
-    "stylelint": "stylelint  \"_sass/**/*.scss\" --fix && npm run tokenize",
+    "stylelint": "npm run browser-list && stylelint  \"_sass/**/*.scss\" --fix && npm run tokenize",
     "lint": "npm run pretty-quick && npm run stylelint",
-    "tokenize": "scss-to-json \"_sass/_variables.scss\" > \"_data/variables.json\""
+    "tokenize": "scss-to-json \"_sass/_variables.scss\" > \"_data/variables.json\"",
+    "browser-list": "echo Browser support list: && npx browserslist",
+    "browser-update": "npx browserslist@latest --update-db"
   },
   "repository": {
     "type": "git",
@@ -22,10 +24,10 @@
   "homepage": "https://github.com/double-great/great-great-jekyll-theme#readme",
   "devDependencies": {
     "husky": "^4.3.0",
-    "prettier": "^2.1.1",
+    "prettier": "^2.1.2",
     "pretty-quick": "^3.0.2",
     "scss-to-json": "^2.0.0",
-    "stylelint": "^13.7.1",
+    "stylelint": "^13.7.2",
     "stylelint-a11y": "^1.2.3",
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-config-standard": "^20.0.0",


### PR DESCRIPTION
- Removes duplicate browserslist config from `.stylelintrc`
- Names `.browserslistrc` properly — missed a "s"
- Updates node dependences
- Adds `npm run browser-list` to display list of supported browsers
- Adds `npm run browser-update` to update the Can I Use DB for latest browser info