### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Jekyll theme for [doublegreat.dev](https://doublegreat.dev).
 Add this line to your Jekyll site's `_config.yml`:
 
 ```yaml
-remote_theme: double-great/great-great-jekyll-theme@gh-pages
+remote_theme: double-great/great-great-jekyll-theme@main
 ```
 
 And add to the `plugins` list:


### PR DESCRIPTION
Hello!

I tried installing this theme following the instructions in the readme but I ran across this error:
```
usr/local/var/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/jekyll-remote-theme-0.4.2/lib/jekyll-remote-theme/downloader.rb:67:in `raise_unless_sucess': 404 - Not Found (Jekyll::RemoteTheme::DownloadError)
```

This error seems to be because the branch mentioned in the Readme is `gh-pages` but the branch in the repo is `main`.

Thanks!