### PR TITLE
Concise but still great

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    great-great-jekyll-theme (1.0.0)
+    great-great-jekyll-theme (2.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.4.4)
+    activesupport (6.0.4.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -19,8 +19,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.17.13)
-      ruby-enum (~> 0.5)
+    commonmarker (0.23.4)
     concurrent-ruby (1.1.9)
     dnsruby (1.61.9)
       simpleidn (~> 0.1)
@@ -31,7 +30,7 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.8.1)
-    faraday (1.9.3)
+    faraday (1.10.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -57,12 +56,12 @@ GEM
     ffi (1.15.5)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
-    github-pages (223)
+    github-pages (225)
       github-pages-health-check (= 1.17.9)
       jekyll (= 3.9.0)
       jekyll-avatar (= 0.7.0)
       jekyll-coffeescript (= 1.1.1)
-      jekyll-commonmark-ghpages (= 0.1.6)
+      jekyll-commonmark-ghpages (= 0.2.0)
       jekyll-default-layout (= 0.1.4)
       jekyll-feed (= 0.15.1)
       jekyll-gist (= 1.5.0)
@@ -76,7 +75,7 @@ GEM
       jekyll-relative-links (= 0.6.1)
       jekyll-remote-theme (= 0.4.3)
       jekyll-sass-converter (= 1.5.2)
-      jekyll-seo-tag (= 2.7.1)
+      jekyll-seo-tag (= 2.8.0)
       jekyll-sitemap (= 1.4.0)
       jekyll-swiss (= 1.0.0)
       jekyll-theme-architect (= 0.2.0)
@@ -132,12 +131,12 @@ GEM
     jekyll-coffeescript (1.1.1)
       coffee-script (~> 2.2)
       coffee-script-source (~> 1.11.1)
-    jekyll-commonmark (1.3.1)
-      commonmarker (~> 0.14)
-      jekyll (>= 3.7, < 5.0)
-    jekyll-commonmark-ghpages (0.1.6)
-      commonmarker (~> 0.17.6)
-      jekyll-commonmark (~> 1.2)
+    jekyll-commonmark (1.4.0)
+      commonmarker (~> 0.22)
+    jekyll-commonmark-ghpages (0.2.0)
+      commonmarker (~> 0.23.4)
+      jekyll (~> 3.9.0)
+      jekyll-commonmark (~> 1.4.0)
       rouge (>= 2.0, < 4.0)
     jekyll-default-layout (0.1.4)
       jekyll (~> 3.0)
@@ -169,7 +168,7 @@ GEM
       rubyzip (>= 1.3.0, < 3.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
-    jekyll-seo-tag (2.7.1)
+    jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
@@ -249,13 +248,11 @@ GEM
     public_suffix (4.0.6)
     racc (1.6.0)
     rake (12.3.3)
-    rb-fsevent (0.11.0)
+    rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (3.26.0)
-    ruby-enum (0.9.0)
-      i18n
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
@@ -278,13 +275,14 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8)
+    unf_ext (0.0.8.1)
     unicode-display_width (1.8.0)
     webrick (1.7.0)
     zeitwerk (2.5.4)
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -294,4 +292,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.3
+   2.3.9

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# great-great-jekyll-theme
+# theme
 
 Jekyll theme for [doublegreat.dev](https://doublegreat.dev).
 
@@ -7,7 +7,7 @@ Jekyll theme for [doublegreat.dev](https://doublegreat.dev).
 Add this line to your Jekyll site's `_config.yml`:
 
 ```yaml
-remote_theme: double-great/great-great-jekyll-theme@main
+remote_theme: double-great/theme@main
 ```
 
 And add to the `plugins` list:

--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,12 @@
 title: Great Great Jekyll Theme
 description: "Jekyll theme for Double Great projects."
 url: "https://doublegreat.dev"
-baseurl: /great-great-jekyll-theme
+baseurl: /theme
 
 author:
   name: "@double-great"
 
-github: double-great/great-great-jekyll-theme
+github: double-great/theme
 
 permalink: /:title/
 

--- a/great-great-jekyll-theme.gemspec
+++ b/great-great-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "great-great-jekyll-theme"
-  spec.version       = "1.0.0"
+  spec.version       = "2.0.0"
   spec.authors       = ["Double Great"]
 
   spec.summary       = "Jekyll theme for doublegreat.dev"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "great-great-jekyll-theme",
-  "version": "1.0.0",
+  "name": "theme",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "great-great-jekyll-theme",
-      "version": "1.0.0",
+      "name": "theme",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@crocsx/scss-to-json": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "great-great-jekyll-theme",
-  "version": "1.0.0",
+  "name": "theme",
+  "version": "2.0.0",
   "description": "Jekyll theme for doublegreat.dev",
   "main": "index.js",
   "scripts": {
@@ -14,14 +14,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/double-great/great-great-jekyll-theme.git"
+    "url": "git+https://github.com/double-great/theme.git"
   },
   "author": "Double Great",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/double-great/great-great-jekyll-theme/issues"
+    "url": "https://github.com/double-great/theme/issues"
   },
-  "homepage": "https://github.com/double-great/great-great-jekyll-theme#readme",
+  "homepage": "https://github.com/double-great/theme#readme",
   "devDependencies": {
     "@crocsx/scss-to-json": "^3.0.0",
     "husky": "^7.0.4",


### PR DESCRIPTION
Renames repo references from `great-great-jeykll-theme` → `theme`. I left the Ruby references in place because my gut tells me that might cause problems.

Next steps:
- [x] Review and merge this PR
- [ ] Change repo name <https://github.com/double-great/great-great-jekyll-theme/settings>
- [x] Open PR in <https://github.com/double-great/double-great.github.io>
- [x] Open PR in <https://github.com/double-great/listen>
- [x] Open PR in <https://github.com/double-great/feedback-library>